### PR TITLE
fix(atlas): install after `go` feature

### DIFF
--- a/src/atlas/NOTES.md
+++ b/src/atlas/NOTES.md
@@ -4,6 +4,12 @@ Only the latest release of the [Community Edition of Atlas](https://atlasgo.io/c
 
 Choosing a specific version will cause it to be built from source.
 
+### Building from source
+
+[Go](https://go.dev/) is required to build the Atlas CLI.
+
+If `go` is neither in the `PATH` nor `/usr/local/go/bin/go`, it is installed from the [Go Feature](https://github.com/devcontainers/features/tree/main/src/go) (skipping tools installation) and is currently available for Debian/Ubuntu-based distributions with the apt package manager installed.
+
 ## Third Party
 
 -   The [Atlas installation script](./atlas.sh) is a copy of the original one from https://atlasgo.sh.

--- a/src/atlas/devcontainer-feature.json
+++ b/src/atlas/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
     "id": "atlas",
-    "version": "1.0.2",
+    "version": "1.0.3",
     "name": "Atlas CLI",
     "description": "[Atlas](https://atlasgo.io) is a language-independent tool for managing and migrating database schemas using modern DevOps principles.",
     "documentationURL": "https://github.com/marcozac/devcontainer-features/tree/main/src/atlas",
@@ -20,9 +20,14 @@
         },
         "goVersion": {
             "type": "string",
-            "proposals": ["1.20.7"],
+            "proposals": [
+                "1.20.7"
+            ],
             "default": "1.20.7",
             "description": "The Go version to use to build a specific (community edition) version of the Atlas CLI"
         }
-    }
+    },
+    "installsAfter": [
+        "ghcr.io/devcontainers/features/go"
+    ]
 }


### PR DESCRIPTION
Go is required for building from source and should be installed before this feature.